### PR TITLE
adds retry mechanism for the installation of Maestro CLI

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -36,7 +36,7 @@ else
 fi
 
 # Install maestro CLI
-curl --retry 5 -Ls "https://get.maestro.mobile.dev" | bash
+curl --retry 5 --retry-all-errors -Ls "https://get.maestro.mobile.dev" | bash
 export PATH="$PATH":"$HOME/.maestro/bin"
 
 # Run Maestro Cloud

--- a/step.sh
+++ b/step.sh
@@ -36,7 +36,7 @@ else
 fi
 
 # Install maestro CLI
-curl -Ls "https://get.maestro.mobile.dev" | bash
+curl --retry 5 -Ls "https://get.maestro.mobile.dev" | bash
 export PATH="$PATH":"$HOME/.maestro/bin"
 
 # Run Maestro Cloud


### PR DESCRIPTION
As I've experienced failures due to `Connection reset` a few times recently, I thought it might be worth adding a retry mechanism when trying to install the Maestro CLI 
```
+ cd /bitrise/src
+ [[ -z '' ]]
+ echo 'Maestro CLI version not specified, using latest'
Maestro CLI version not specified, using latest
+ curl -Ls https://get.maestro.mobile.dev/
+ bash
* Create distribution directories...
* Downloading...
#=#=#                                                                         
curl: (35) OpenSSL SSL_connect: Connection reset by peer in connection to objects.githubusercontent.com:443
```