### PR TITLE
Make app-file and workspace parameters explicit rather than inferred

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -78,7 +78,8 @@ ${is_export:+--format "junit"} \
 ${export_file:+--output "$export_file"} \
 ${env_list:+ $env_list} \
 ${timeout:+--timeout "$timeout"} \
-$app_file $workspace || EXIT_CODE=$?
+--app-file "$app_file" \
+--flows "$workspace" || EXIT_CODE=$?
 
 # Export test results
 if [[ -n "$export_file" && -f "$export_file" ]]; then


### PR DESCRIPTION
From a conversation in the community Slack ([link](https://maestro--dev.slack.com/archives/C041FU72T54/p1758017808874629?thread_ts=1758013908.490709&cid=C041FU72T54)) where a user received:

```
Missing required parameters: '--app-file', '--flows'. Example: maestro cloud --app-file <path> --flows <path>
```

These aren't required and can be inferred, but perhaps spaces in naming could make the inference break.

Explicit > implicit, every time.

Whilst I've not got a Bitrise env set up to test this, I've validated the command construction manually and using copilot against the output of `maestro cloud --help`.