### PR TITLE
Bump to v1.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.9.0 - 2026-05-01
+
+- Deprecated `android_api_level` input — use `device_os` (e.g. `android-33`) instead. Setting `android_api_level` now logs a warning; the input will be removed in a future release.
+- Improved `device_os` and `device_model` docs to cover both iOS and Android, with examples
+- Added tests for the `android_api_level` deprecation behaviour
+
 ## 1.8.0 - 2026-03-18
 
 - Added outputs for the Maestro Cloud Run URL and App Binary ID

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -5,7 +5,7 @@ app:
   envs:
     # If you want to share this step into a StepLib
     - BITRISE_STEP_ID: maestro-cloud-upload
-    - BITRISE_STEP_VERSION: "1.8.0"
+    - BITRISE_STEP_VERSION: "1.9.0"
     - BITRISE_STEP_GIT_CLONE_URL: https://github.com/mobile-dev-inc/bitrise-step-maestro-cloud-upload.git
     - MY_STEPLIB_REPO_FORK_GIT_URL: git@github.com:mobile-dev-inc/bitrise-steplib.git
 


### PR DESCRIPTION
## Summary

- Adds a CHANGELOG entry for 1.9.0 covering the `android_api_level` deprecation, the `device_os` / `device_model` doc improvements, and BATS coverage for the deprecation warning
- Bumps `BITRISE_STEP_VERSION` in `bitrise.yml` to `1.9.0`

Mirrors the version-bump pattern from #30 (1.8.0). RELEASING.md is being added in a separate PR to keep this diff minimal.

## Test plan

- [ ] Run BATS suite locally: `BATS_LIB_PATH=\`npm root -g\` bats test.bats`
- [ ] Confirm CHANGELOG entry renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)